### PR TITLE
Add platform for Atom.

### DIFF
--- a/sections/apps.md
+++ b/sections/apps.md
@@ -17,4 +17,4 @@
 - [CSS Hat](http://csshat.com/) - Win/Mac
 - [Screenflick](http://www.araelium.com/screenflick) - Mac
 - [Shuttle](http://fitztrev.github.io/shuttle/) - Mac
-- [Atom](https://atom.io/)
+- [Atom](https://atom.io/) - Mac


### PR DESCRIPTION
Note: Today there is a version for Linux, but is as BETA.
